### PR TITLE
안드로이드에서 지도 표시 기능 구현 (ISSUE-95)

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -3,6 +3,16 @@ apply plugin: "org.jetbrains.kotlin.android"
 apply plugin: "com.facebook.react"
 
 def projectRoot = rootDir.getAbsoluteFile().getParentFile().getAbsolutePath()
+def localPropertiesFile = new File(projectRoot, "/android/local.properties")
+
+def localProperties = new Properties()
+if (localPropertiesFile.exists()) {
+  localProperties.load(new FileInputStream(localPropertiesFile))
+} else {
+  throw new GradleException("cannot load ${localPropertiesFile}. ")
+}
+
+def MAPS_API_KEY = localProperties.getProperty("MAPS_API_KEY") ?: ""
 
 /**
  * This is the configuration block to customize your React Native Android app.
@@ -93,6 +103,8 @@ android {
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode 1
         versionName "1.0.0"
+        resValue "string", "google_maps_key", MAPS_API_KEY
+        buildConfigField "String", "MAPS_API_KEY", "\"${MAPS_API_KEY}\""
     }
     signingConfigs {
         debug {

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -19,7 +19,7 @@
     <meta-data android:name="expo.modules.updates.EXPO_UPDATES_LAUNCH_WAIT_MS" android:value="0"/>
     <meta-data
       android:name="com.google.android.geo.API_KEY"
-      android:value=""/>
+      android:value="@string/google_maps_key" />
     <activity android:name=".MainActivity" android:configChanges="keyboard|keyboardHidden|orientation|screenSize|screenLayout|uiMode" android:launchMode="singleTask" android:windowSoftInputMode="adjustResize" android:theme="@style/Theme.App.SplashScreen" android:exported="true" android:screenOrientation="portrait">
       <intent-filter>
         <action android:name="android.intent.action.MAIN"/>


### PR DESCRIPTION
# 변경점 👍
Expo Docs에서 명시한대로 app config에서 환경변수를 읽어와 추가해봤지만 효과가 없어
빌드 단에서 local.properties 파일을 통해 API KEY를 읽어오도록 설정했습니다.

## android에서 지도 표시하는 방법
`/android/local.properties`파일을 아래와 같이 수정하면 자동으로 로드됩니다. local.properties는 prebuild 생성 시 기본적으로 gitignore에 추가되어 있어 별다른 ignore 설정은 필요하지 않습니다.
```
sdk.dir=기본 생성된 내용
MAPS_API_KEY=구글지도 API Key
```
 
# 스크린샷 🖼
![image](https://github.com/user-attachments/assets/b5a30baf-f617-4a4c-b083-da953e477cf1)

